### PR TITLE
CD-2725 Generate stats directly to mbtiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Ignore/limit attribute values [#1](https://github.com/maptiler/mapbox-geostats/pull/1)
 - `buildGeoStats` rejects promise instead of throwing an error [#3](https://github.com/maptiler/mapbox-geostats/pull/3)
 - Add an option to insert generated tilestats into mbtiles metadata [#3](https://github.com/maptiler/mapbox-geostats/pull/3)
+- Split geostats and validator tests [#3](https://github.com/maptiler/mapbox-geostats/pull/3)
 
 # 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Ignore/limit attribute values [#1](https://github.com/maptiler/mapbox-geostats/pull/1)
 - `buildGeoStats` rejects promise instead of throwing an error [#3](https://github.com/maptiler/mapbox-geostats/pull/3)
+- Add an option to insert generated tilestats into mbtiles metadata [#3](https://github.com/maptiler/mapbox-geostats/pull/3)
 
 # 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # DEVEL
 
 - Ignore/limit attribute values [#1](https://github.com/maptiler/mapbox-geostats/pull/1)
+- `buildGeoStats` rejects promise instead of throwing an error [#3](https://github.com/maptiler/mapbox-geostats/pull/3)
 
 # 1.1.2
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Generate statistics about geographic data.
 
 ## Installation
 
+Requires Node v16+.
+
 ```
 git clone https://github.com/maptiler/mapbox-geostats.git
 cd mapbox-geostats
@@ -54,11 +56,21 @@ Generate statistics about geographic data.
 Usage
   mapbox-geostats <input> <options>
 
-  Output is logged to the console as a JSON string.
+  Output is logged to the console as a JSON string or written into mbtiles
+  when using --into-md option.
 
 Options
   --attributes, -a Specify attributes to analyze. The provided value
                    will be parsed as an array, split on commas.
+  --force-all-attributes, -f Include values of these attributes: id,
+                             name, name1, name2, name_en, name_de,
+                             originalid, adm0_l, amd0_r, disputed_name,
+                             ref, fid, uuid.
+  --tile-stats-values-limit Limit the number of unique attribute values to
+                            report. Default: 50. If exceeded, show min and
+                            max instead.
+  --into-md Insert generated tilestats into mbtiles metadata table. Fail
+            when tilestats already exist. Output is empty on success.
 
 Example
   mapbox-geostats population-centers.geojson --attributes name,pop > output.json

--- a/bin/mapbox-geostats
+++ b/bin/mapbox-geostats
@@ -9,7 +9,8 @@ const help = `
   Usage
     mapbox-geostats <input> <options>
 
-    Output is logged to the console as a JSON string.
+    Output is logged to the console as a JSON string or written into mbtiles
+    when using --into-md option.
 
   Options
     --attributes, -a Specify attributes to analyze. The provided value
@@ -22,7 +23,7 @@ const help = `
                               report. Default: 50. If exceeded, show min and
                               max instead.
     --into-md Insert generated tilestats into mbtiles metadata table. Fail
-              when tilestats already exist.
+              when tilestats already exist. Output is empty on success.
 
   Example
     mapbox-geostats cities.geojson --attributes name,pop > output.json

--- a/bin/mapbox-geostats
+++ b/bin/mapbox-geostats
@@ -21,6 +21,8 @@ const help = `
     --tile-stats-values-limit Limit the number of unique attribute values to
                               report. Default: 50. If exceeded, show min and
                               max instead.
+    --into-md Insert generated tilestats into mbtiles metadata table. Fail
+              when tilestats already exist.
 
   Example
     mapbox-geostats cities.geojson --attributes name,pop > output.json
@@ -40,6 +42,9 @@ const cli = meow(help, {
       type: 'number',
       default: 50,
     },
+    intoMd: {
+      type: 'boolean',
+    },
   },
 });
 
@@ -48,6 +53,7 @@ const input = cli.input[0];
 const options = {
   forceAllAttributes: cli.flags.forceAllAttributes,
   maxValuesToReport: cli.flags.tileStatsValuesLimit,
+  intoMd: cli.flags.intoMd,
 };
 
 if (cli.flags.attributes) {
@@ -58,7 +64,9 @@ if (!input) {
   console.log(cli.help);
 } else {
   geostats(input, options).then((stats) => {
-    console.log(JSON.stringify(stats));
+    if (!options.intoMd) {
+      console.log(JSON.stringify(stats));
+    }
   }).catch((err) => {
     console.error(err.stack);
   });

--- a/index.js
+++ b/index.js
@@ -11,9 +11,8 @@ const Constants = require('./lib/constants');
  * @param {Object} options
  * @returns {Object} The stats.
  */
-function buildGeoStats(filePath, options) {
+async function buildGeoStats(filePath, options) {
   options = options || {};
-  options.forceAllAttributes ??= false;
   options.maxValuesToReport ??= 50;
 
   if (options.attributes) {
@@ -25,14 +24,12 @@ function buildGeoStats(filePath, options) {
     options.attributes = new Set(options.attributes);
   }
 
-  return getFileType(filePath)
-    .then(function(fileType) {
-      if (fileType === Constants.FILETYPE_MBTILES) return tileAnalyze(filePath, options);
-      return mapnikAnalyze(filePath, fileType, options);
-    })
-    .then(function(stats) {
-      return reportStats(stats, options);
-    });
+  const fileType = await getFileType(filePath);
+  const stats = fileType === Constants.FILETYPE_MBTILES
+    ? await tileAnalyze(filePath, options)
+    : mapnikAnalyze(filePath, fileType, options);
+
+  return reportStats(stats, options);
 }
 
 module.exports = buildGeoStats;

--- a/lib/mapnik-analyze.js
+++ b/lib/mapnik-analyze.js
@@ -26,7 +26,7 @@ mapnik.register_default_input_plugins();
  * @return {Object} The stats.
  */
 module.exports = function(filePath, fileType, options) {
-  if (options.intoMd) throw new Error('Option --into-md can be used only for mbtiles.');
+  if (options.intoMd) throw new Error('Option --into-md can be used only for mbtiles');
 
   const stats = createStats();
   // Derive a fake layer name from the file's name

--- a/lib/mapnik-analyze.js
+++ b/lib/mapnik-analyze.js
@@ -26,7 +26,8 @@ mapnik.register_default_input_plugins();
  * @return {Object} The stats.
  */
 module.exports = function(filePath, fileType, options) {
-  options = options || {};
+  if (options.intoMd) throw new Error('Option --into-md can be used only for mbtiles.');
+
   const stats = createStats();
   // Derive a fake layer name from the file's name
   const layerName = path.basename(filePath, path.extname(filePath));

--- a/lib/report-stats.js
+++ b/lib/report-stats.js
@@ -15,8 +15,7 @@ const briefAttributes = ['id', 'name', 'name1', 'name2', 'name_en', 'name_de', '
 module.exports = function(stats, options) {
 
   // if we have a stats object already built from an mbtiles file
-  if (!stats.layerCountSet &&
-      stats.layerCount) return stats;
+  if (!stats.layerCountSet && Number.isInteger(stats.layerCount)) return stats;
 
   return {
     layerCount: stats.layerCountSet.size,

--- a/lib/tile-analyze.js
+++ b/lib/tile-analyze.js
@@ -69,6 +69,7 @@ module.exports = async function tileAnalyze(filePath, options) {
     const report = reportStats(tilestats, options);
     const metadata = { tilestats: report };
     if (info.vector_layers) metadata.vector_layers = info.vector_layers;
+    else console.warn('Missing vector_layers in metadata json!');
     try {
       await writeMetadata(source, metadata);
     } catch (err) {

--- a/lib/tile-analyze.js
+++ b/lib/tile-analyze.js
@@ -14,6 +14,7 @@ const typeIntegerToString = require('./type-integer-to-string');
 const createStats = require('./create-stats');
 const Constants = require('./constants');
 const validator = require('./validate-stats');
+const reportStats = require('./report-stats');
 
 const VectorTile = mapboxVectorTile.VectorTile;
 
@@ -44,102 +45,168 @@ class TileAnalyzeStream extends Transform {
 
 /**
  * Returns stats about an MBTiles file.
+ * Check if the tilestats object has been pre-generated in the mbtiles file.
+ * If so, return that, otherwise generate it with analyzeSourceStream.
  *
  * @param {string} filePath
  * @param {Object} [options]
  * @param {Array<string>} [options.attributes]
+ * @param {boolean} [options.intoMd]
  * @return {Object} The stats.
  */
-module.exports = function(filePath, options) {
-  options = options || {};
+module.exports = async function tileAnalyze(filePath, options) {
+  const source = await getSource(filePath);
+
+  const info = await getMetadata(source);
+  if (info.tilestats && validator(info.tilestats)) {
+    if (options.intoMd) throw new Error('Tilestats already exists, use without --into-md');
+    return info.tilestats;
+  }
+
+  const tilestats = await analyzeSourceStream(source, options);
+
+  if (options.intoMd) {
+    const report = reportStats(tilestats, options);
+    const metadata = { tilestats: report };
+    if (info.vector_layers) metadata.vector_layers = info.vector_layers;
+    try {
+      await writeMetadata(source, metadata);
+    } catch (err) {
+      throw new Error('Error writing metadata: ' + err);
+    }
+    return report;
+  }
+
+  return tilestats;
+};
+
+/**
+ * Write metadata into MBTiles file
+ *
+ * @param {MBTiles} mbtiles
+ * @param {Object} metadata
+ */
+function writeMetadata(mbtiles, metadata) {
+  return new Promise((resolve, reject) => {
+    mbtiles.startWriting(function(err) {
+      if (err) return reject(err);
+
+      const jsonRow = { json: JSON.stringify(metadata) };
+      mbtiles.putInfo(jsonRow, function(err) {
+        if (err) return reject(err);
+
+        mbtiles.stopWriting(function(err) {
+          if (err) return reject(err);
+          resolve();
+        });
+      });
+    });
+  });
+}
+
+function getMetadata(mbtiles) {
+  return new Promise((resolve, reject) => {
+    mbtiles.getInfo((err, info) => {
+      if (err) reject(err);
+      if (info && validator(info)) {
+        return resolve(info);
+      }
+    });
+  });
+}
+
+function getSource(filePath) {
+  return new Promise((resolve, reject) => {
+    new MBTiles(filePath, (err, source) => {
+      if (err) return reject(err);
+      resolve(source);
+    });
+  });
+}
+
+/**
+ * Generate stats from an MBTiles file.
+ *
+ * @param {MBTiles} source
+ * @param {Object} options
+ * @returns {Object} The stats.
+ */
+async function analyzeSourceStream(source, options) {
   const stats = createStats();
   const layerMap = {};
+  const zxyStream = source.createZXYStream();
+  const readStream = tilelive.createReadStream(source, { type: 'list' });
+  return new Promise((resolve, reject) => {
+    zxyStream.on('error', reject)
+      .pipe(readStream)
+      .pipe(new TileAnalyzeStream((tile) => analyzeTile(tile, stats, layerMap, options)))
+      .on('error', reject)
+      .on('end', async() => {
+        resolve(Object.assign(stats, {
+          layers: Object.values(layerMap),
+        }));
+      })
+      .resume();
+  });
+}
 
-  function getSource() {
-    return new Promise((resolve, reject) => {
-      new MBTiles(filePath, (err, source) => {
-        if (err) return reject(err);
-        resolve(source);
-      });
-    });
-  }
-
-  function analyzeSourceStream(source) {
-    return new Promise((resolve, reject) => {
-
-      // check if the tilestats object has been pre-generated in the mbtiles file
-      // if so, return that, otherwise generate it it with analyzeSourceStream
-      source.getInfo((err, info) => {
-        if (err) reject(err);
-        if (info.tilestats && validator(info.tilestats)) return resolve(info.tilestats);
-
-        const zxyStream = source.createZXYStream();
-        const readStream = tilelive.createReadStream(source, { type: 'list' });
-        zxyStream.on('error', reject)
-          .pipe(readStream)
-          .pipe(new TileAnalyzeStream(analyzeTile))
-          .on('error', reject)
-          .on('end', () => {
-            resolve(Object.assign(stats, {
-              layers: Object.values(layerMap),
-            }));
-          })
-          .resume();
-      });
-    });
-  }
-
-  // Unzips and parses tile data, then analyzes each layer
-  function analyzeTile(tile) {
-    return new Promise((resolve, reject) => {
-      zlib.gunzip(tile.buffer, (err, inflatedBuffer) => {
-        // We'll get this error if the data was not gzipped.
-        // So we'll just use the original data.
-        if (err && err.errno === zlib.constants.Z_DATA_ERROR) {
-          inflatedBuffer = tile.buffer;
-        } else if (err) {
-          return reject(err);
+/**
+ * Unzips and parses tile data, then analyzes each layer
+ *
+ * @param {Object} tile
+ * @param {Object} stats
+ * @param {Object} layerMap
+ * @param {Object} options
+ * @returns {Promise<any>}
+ */
+function analyzeTile(tile, stats, layerMap, options) {
+  return new Promise((resolve, reject) => {
+    zlib.gunzip(tile.buffer, (err, inflatedBuffer) => {
+      // We'll get this error if the data was not gzipped.
+      // So we'll just use the original data.
+      if (err && err.errno === zlib.constants.Z_DATA_ERROR) {
+        inflatedBuffer = tile.buffer;
+      } else if (err) {
+        return reject(err);
+      }
+      let vectorTile;
+      try {
+        vectorTile = new VectorTile(new Protobuf(inflatedBuffer));
+      } catch (e) {
+        // We'll get this error if the data cannot be interpreted as a vector tile.
+        // We skip this in order to see if we can gather data from other tiles.
+        if (e.message.indexOf('Unimplemented type') === 0) return resolve();
+        return reject(e);
+      }
+      for (const layerName in vectorTile.layers) {
+        if (Object.hasOwnProperty.call(vectorTile.layers, layerName)) {
+          const layerData = vectorTile.layers[layerName];
+          analyzeLayer(layerData, layerName, stats.layerCountSet, layerMap, options);
         }
-        let vectorTile;
-        try {
-          vectorTile = new VectorTile(new Protobuf(inflatedBuffer));
-        } catch (e) {
-          // We'll get this error if the data cannot be interpreted as a vector tile.
-          // We skip this in order to see if we can gather data from other tiles.
-          if (e.message.indexOf('Unimplemented type') === 0) return resolve();
-          return reject(e);
-        }
-        for (const layerName in vectorTile.layers) {
-          if (Object.hasOwnProperty.call(vectorTile.layers, layerName)) {
-            analyzeLayer(vectorTile.layers[layerName], layerName);
-          }
-        }
-        resolve();
-      });
+      }
+      resolve();
     });
+  });
+}
+
+function analyzeLayer(layerData, rawLayerName, layerCountSet, layerMap, options) {
+  const layerName = rawLayerName.slice(0, Constants.NAME_TRUNCATE_LENGTH);
+  if (layerMap[layerName] === undefined) {
+    if (layerCountSet.size > Constants.LAYERS_MAX_COUNT) return;
+    layerCountSet.add(layerName);
+
+    if (layerCountSet.size > Constants.LAYERS_MAX_REPORT) return;
+    layerMap[layerName] = createLayerStats(layerName);
   }
-
-  function analyzeLayer(layerData, rawLayerName) {
-    const layerName = rawLayerName.slice(0, Constants.NAME_TRUNCATE_LENGTH);
-    if (layerMap[layerName] === undefined) {
-      if (stats.layerCountSet.size > Constants.LAYERS_MAX_COUNT) return;
-      stats.layerCountSet.add(layerName);
-
-      if (stats.layerCountSet.size > Constants.LAYERS_MAX_REPORT) return;
-      layerMap[layerName] = createLayerStats(layerName);
-    }
-    const layerStats = layerMap[layerName];
-    for (let i = 0, l = layerData.length; i < l; i++) {
-      analyzeFeature(layerStats, layerData.feature(i));
-    }
+  const layerStats = layerMap[layerName];
+  for (let i = 0, l = layerData.length; i < l; i++) {
+    analyzeFeature(layerStats, layerData.feature(i), options);
   }
+}
 
-  function analyzeFeature(layerStats, feature) {
-    registerFeature(layerStats, {
-      type: typeIntegerToString(feature.type),
-    });
-    registerAttributesMap(layerStats, options, feature.properties);
-  }
-
-  return getSource(filePath).then(analyzeSourceStream);
-};
+function analyzeFeature(layerStats, feature, options) {
+  registerFeature(layerStats, {
+    type: typeIntegerToString(feature.type),
+  });
+  registerAttributesMap(layerStats, options, feature.properties);
+}

--- a/lib/tile-analyze.js
+++ b/lib/tile-analyze.js
@@ -59,7 +59,7 @@ module.exports = async function tileAnalyze(filePath, options) {
 
   const info = await getMetadata(source);
   if (info.tilestats && validator(info.tilestats)) {
-    if (options.intoMd) throw new Error('Tilestats already exists, use without --into-md');
+    if (options.intoMd) throw new Error('Tilestats already exist in json record of metadata table, run without --into-md to display them');
     return info.tilestats;
   }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "lint": "eslint lib test bin/**",
     "lint-fix": "eslint --fix lib test bin/**",
-    "test": "npm run lint && tap test/test.js --no-check-coverage",
+    "test": "npm run lint && tap test/*.js --no-check-coverage",
     "coverage": "tap test/test.js --cov --coverage-report=html"
   },
   "repository": {

--- a/test/geostats.js
+++ b/test/geostats.js
@@ -378,7 +378,7 @@ t.test('MBTiles with option --into-md', async(t) => {
 
   t.rejects(
     geostats(tmpFilename, { intoMd: true }),
-    new Error('Tilestats already exists, use without --into-md'),
+    new Error('Tilestats already exist in json record of metadata table, run without --into-md to display them'),
   );
 
   const preGenStats = await geostats(tmpFilename);

--- a/test/geostats.js
+++ b/test/geostats.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const test = require('tap').test;
-const skip = require('tap').skip;
-const before = require('tap').before;
-const teardown = require('tap').teardown;
+const t = require('tap');
 const path = require('path');
 const fs = require('fs').promises;
 const sloppySort = require('./utils/sloppy-sort');
@@ -23,14 +20,14 @@ async function getExpected(name) {
 
 let tmpPath;
 
-before(async() => {
+t.before(async() => {
   tmpPath = await fs.mkdtemp(fixturePath('tmp-'));
   return tmpPath;
 });
 
-teardown(() => fs.rm(tmpPath, { recursive: true }));
+t.teardown(() => fs.rm(tmpPath, { recursive: true }));
 
-test('Errors without a file path', t => {
+t.test('Errors without a file path', t => {
   geostats().then(() => {
     t.fail('should have errored');
     t.end();
@@ -40,7 +37,7 @@ test('Errors without a file path', t => {
   });
 });
 
-test('Errors when MBTiles file not found', t => {
+t.test('Errors when MBTiles file not found', t => {
   geostats(fixturePath('doodoodoo.mbtiles')).then(() => {
     t.fail('should have errored');
     t.end();
@@ -50,7 +47,7 @@ test('Errors when MBTiles file not found', t => {
   });
 });
 
-test('Errors when Mapnik-interpreted file not found', t => {
+t.test('Errors when Mapnik-interpreted file not found', t => {
   geostats(fixturePath('doodoodoo.csv')).then(() => {
     t.fail('should have errored');
     t.end();
@@ -60,7 +57,7 @@ test('Errors when Mapnik-interpreted file not found', t => {
   });
 });
 
-test('GeoJSON with many value types, input matching MBTiles, forceAllAttributes', t => {
+t.test('GeoJSON with many value types, input matching MBTiles, forceAllAttributes', t => {
   Promise.all([
     geostats(fixturePath('src/many-types.geojson'), { forceAllAttributes: true }),
     getExpected('many-types-geojson'),
@@ -73,7 +70,7 @@ test('GeoJSON with many value types, input matching MBTiles, forceAllAttributes'
 // Key difference between the MBTiles and the GeoJSON output now
 // is that when Mapnik reads the GeoJSON it inserts `null` values
 // in weird places
-test('MBTiles with many value types, input matching GeoJSON', t => {
+t.test('MBTiles with many value types, input matching GeoJSON', t => {
   Promise.all([
     geostats(fixturePath('src/many-types.mbtiles')),
     getExpected('many-types-mbtiles'),
@@ -83,7 +80,7 @@ test('MBTiles with many value types, input matching GeoJSON', t => {
   }).catch(t.threw);
 });
 
-test('GeoJSON with over 100 unique attributes and values, input matching Shapefile and CSV',
+t.test('GeoJSON with over 100 unique attributes and values, input matching Shapefile and CSV',
   t => {
     Promise.all([
       geostats(fixturePath('src/populations-plus.geojson')),
@@ -98,7 +95,7 @@ test('GeoJSON with over 100 unique attributes and values, input matching Shapefi
 // Key difference between the Shapefile and the GeoJSON output right now
 // seems to be that the shapefile has converted `null` to `""` in
 // predominantly string-valued attributes
-test('Shapefile with over 100 unique attributes and values, input matching GeoJSON and CSV',
+t.test('Shapefile with over 100 unique attributes and values, input matching GeoJSON and CSV',
   t => {
     Promise.all([
       geostats(fixturePath('src/populations-plus/populations-plus.shp')),
@@ -112,7 +109,7 @@ test('Shapefile with over 100 unique attributes and values, input matching GeoJS
 
 // Key difference between the CSV and Shapefile and GeoJSON is that it
 // includes X and Y attributes (it also converts `null` to `""`, like Shapefile)
-test('CSV with over 100 unique attributes and values, input matching GeoJSON and Shapefile',
+t.test('CSV with over 100 unique attributes and values, input matching GeoJSON and Shapefile',
   t => {
     Promise.all([
       geostats(fixturePath('src/populations-plus.csv')),
@@ -124,7 +121,7 @@ test('CSV with over 100 unique attributes and values, input matching GeoJSON and
   },
 );
 
-test('MBTiles with gzipped data', t => {
+t.test('MBTiles with gzipped data', t => {
   Promise.all([
     geostats(fixturePath('src/vectorgzip.mbtiles')),
     getExpected('vectorgzip'),
@@ -134,14 +131,14 @@ test('MBTiles with gzipped data', t => {
   }).catch(t.threw);
 });
 
-test('MBTiles with raster data', t => {
+t.test('MBTiles with raster data', t => {
   geostats(fixturePath('src/pngs.mbtiles')).then((output) => {
     t.same(output, { layerCount: 0, layers: [] }, 'empty output');
     t.end();
   }).catch(t.threw);
 });
 
-test('GeoJSON with over 1000 unique attributes', t => {
+t.test('GeoJSON with over 1000 unique attributes', t => {
   Promise.all([
     geostats(fixturePath('src/two-thousand-properties.geojson')),
     getExpected('two-thousand-properties'),
@@ -154,7 +151,7 @@ test('GeoJSON with over 1000 unique attributes', t => {
   }).catch(t.threw);
 });
 
-test('GeoJSON with many geometry types', t => {
+t.test('GeoJSON with many geometry types', t => {
   Promise.all([
     geostats(fixturePath('src/geometry-extravaganza.geojson')),
     getExpected('geometry-extravaganza'),
@@ -164,14 +161,14 @@ test('GeoJSON with many geometry types', t => {
   }).catch(t.threw);
 });
 
-test('MBTiles with no features', t => {
+t.test('MBTiles with no features', t => {
   geostats(fixturePath('src/no-features.mbtiles')).then((output) => {
     t.same(output, { layerCount: 0, layers: [] }, 'empty output');
     t.end();
   }).catch(t.threw);
 });
 
-test('Shapefile with no features', t => {
+t.test('Shapefile with no features', t => {
   Promise.all([
     geostats(fixturePath('src/no-features/no-features.shp')),
     getExpected('no-features'),
@@ -181,7 +178,7 @@ test('Shapefile with no features', t => {
   }).catch(t.threw);
 });
 
-test('CSV with no features', t => {
+t.test('CSV with no features', t => {
   Promise.all([
     geostats(fixturePath('src/no-features.csv')),
     getExpected('no-features'),
@@ -192,7 +189,7 @@ test('CSV with no features', t => {
 });
 
 // Currently this is blocked by a bug in node-mapnik
-skip('GeoJSON with no features still outputs', t => {
+t.skip('GeoJSON with no features still outputs', t => {
   geostats(fixturePath('src/no-features.geojson')).then((output) => {
     const expected = {
       layerCount: 1,
@@ -210,7 +207,7 @@ skip('GeoJSON with no features still outputs', t => {
   }).catch(t.threw);
 });
 
-test('invalid GeoJSON', t => {
+t.test('invalid GeoJSON', t => {
   geostats(fixturePath('src/invalid.geojson')).then(() => {
     t.fail('should have errored');
     t.end();
@@ -220,7 +217,7 @@ test('invalid GeoJSON', t => {
   });
 });
 
-test('GeoJSON skips invalid geometry types', t => {
+t.test('GeoJSON skips invalid geometry types', t => {
   Promise.all([
     geostats(fixturePath('src/geometry-invalid-types.geojson')),
     getExpected('geojson-invalid-geometry-types'),
@@ -232,7 +229,7 @@ test('GeoJSON skips invalid geometry types', t => {
   });
 });
 
-test('invalid Shapefile', t => {
+t.test('invalid Shapefile', t => {
   geostats(fixturePath('src/invalid.shp')).then(() => {
     t.fail('should have errored');
     t.end();
@@ -242,7 +239,7 @@ test('invalid Shapefile', t => {
   });
 });
 
-test('invalid CSV', t => {
+t.test('invalid CSV', t => {
   geostats(fixturePath('src/invalid.csv')).then(() => {
     t.fail('should have errored');
     t.end();
@@ -252,7 +249,7 @@ test('invalid CSV', t => {
   });
 });
 
-test('invalid MBTiles', t => {
+t.test('invalid MBTiles', t => {
   geostats(fixturePath('src/invalid.mbtiles')).then(() => {
     t.fail('should have errored');
     t.end();
@@ -262,7 +259,7 @@ test('invalid MBTiles', t => {
   });
 });
 
-test('invalid file format', t => {
+t.test('invalid file format', t => {
   geostats(fixturePath('src/invalid.txt')).then(() => {
     t.fail('should have errored');
     t.end();
@@ -272,7 +269,7 @@ test('invalid file format', t => {
   });
 });
 
-test('GeoJSON with specified name attribute', t => {
+t.test('GeoJSON with specified name attribute', t => {
   Promise.all([
     geostats(fixturePath('src/many-types.geojson'), {
       attributes: ['name'],
@@ -285,7 +282,7 @@ test('GeoJSON with specified name attribute', t => {
   }).catch(t.threw);
 });
 
-test('GeoJSON with specified attributes', t => {
+t.test('GeoJSON with specified attributes', t => {
   Promise.all([
     geostats(fixturePath('src/two-thousand-properties.geojson'), {
       attributes: ['prop-21', 'prop-1031'],
@@ -297,7 +294,7 @@ test('GeoJSON with specified attributes', t => {
   }).catch(t.threw);
 });
 
-test('Trying to report on more than 100 attributes', t => {
+t.test('Trying to report on more than 100 attributes', t => {
   t.rejects(geostats(fixturePath('src/populations-plus.geojson'), {
       attributes: ['attr-0', 'attr-1', 'attr-2', 'attr-3', 'attr-4', 'attr-5',
         'attr-6', 'attr-7', 'attr-8', 'attr-9', 'attr-10', 'attr-11', 'attr-12',
@@ -321,7 +318,7 @@ test('Trying to report on more than 100 attributes', t => {
   t.end();
 });
 
-test('GeoJSON with prototype attribute', t => {
+t.test('GeoJSON with prototype attribute', t => {
   Promise.all([
     geostats(fixturePath('src/prototype.geojson')),
     getExpected('prototype'),
@@ -331,7 +328,7 @@ test('GeoJSON with prototype attribute', t => {
   }).catch(t.threw);
 });
 
-test('truncate attribute names', t => {
+t.test('truncate attribute names', t => {
   Promise.all([
     geostats(fixturePath('src/long-attribute-names.geojson')),
     getExpected('long-attribute-names'),
@@ -341,7 +338,7 @@ test('truncate attribute names', t => {
   }).catch(t.threw);
 });
 
-test('MBTiles with two layers', t => {
+t.test('MBTiles with two layers', t => {
   Promise.all([
     geostats(fixturePath('src/two-layers.mbtiles')),
     getExpected('two-layers'),
@@ -351,7 +348,7 @@ test('MBTiles with two layers', t => {
   }).catch(t.threw);
 });
 
-test('MBTiles with tilestats metadata table returns as expected', t => {
+t.test('MBTiles with tilestats metadata table returns as expected', t => {
   Promise.all([
     geostats(fixturePath('src/tilestats.mbtiles')),
     getExpected('tilestats'),
@@ -361,7 +358,7 @@ test('MBTiles with tilestats metadata table returns as expected', t => {
   }).catch(t.threw);
 });
 
-test('option --into-md with non MBTiles file', t => {
+t.test('option --into-md with non MBTiles file', t => {
   t.rejects(
     geostats(fixturePath('src/many-types.geojson'), { intoMd: true }),
     new Error('Option --into-md can be used only for mbtiles'),
@@ -369,7 +366,7 @@ test('option --into-md with non MBTiles file', t => {
   t.end();
 });
 
-test('MBTiles with option --into-md', async(t) => {
+t.test('MBTiles with option --into-md', async(t) => {
   const tmpFilename = path.join(tmpPath, 'many-types.mbtiles');
   await fs.copyFile(fixturePath('src/many-types.mbtiles'), tmpFilename);
 

--- a/test/test.js
+++ b/test/test.js
@@ -288,8 +288,7 @@ test('GeoJSON with specified attributes', t => {
 });
 
 test('Trying to report on more than 100 attributes', t => {
-  t.throws(() => {
-    geostats(fixturePath('src/populations-plus.geojson'), {
+  t.rejects(geostats(fixturePath('src/populations-plus.geojson'), {
       attributes: ['attr-0', 'attr-1', 'attr-2', 'attr-3', 'attr-4', 'attr-5',
         'attr-6', 'attr-7', 'attr-8', 'attr-9', 'attr-10', 'attr-11', 'attr-12',
         'attr-13', 'attr-14', 'attr-15', 'attr-16', 'attr-17', 'attr-18', 'attr-19',
@@ -307,8 +306,8 @@ test('Trying to report on more than 100 attributes', t => {
         'attr-97', 'attr-98', 'attr-99', 'attr-100', 'attr-101', 'attr-102',
         'attr-103', 'attr-104', 'attr-105', 'attr-106', 'attr-107', 'attr-108',
         'attr-109'],
-    });
-  }, 'throws');
+    }), new Error('Cannot report on more than 100 attributes'),
+  );
   t.end();
 });
 

--- a/test/validator.js
+++ b/test/validator.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const test = require('tap').test;
+const sloppySort = require('./utils/sloppy-sort');
+const validator = require('../lib/validate-stats');
+
+test('valid stats object', t => {
+  const stats = {
+    layerCount: 1,
+    layers: [
+      {
+        layer: 'test-layer',
+        count: 3,
+        geometry: 'Point',
+        attributeCount: 1,
+        attributes: [
+          {
+            attribute: 'test-attribute',
+            count: 3,
+            type: 'number',
+            values: [2, 5, 19],
+            min: 2,
+            max: 19,
+          },
+        ],
+      },
+    ],
+  };
+
+  t.ok(validator(stats));
+  t.end();
+});
+
+test('invalid stats object - no layers', t => {
+  const stats = {
+    layerCount: 1,
+  };
+
+  const results = validator(stats);
+  t.equal(results.length, 1, 'only one error');
+  t.equal(results[0], 'instance requires property "layers"', 'expected error message');
+  t.end();
+});
+
+test('invalid layer object - no layer name', t => {
+  const stats = {
+    layerCount: 1,
+    layers: [
+      {
+        count: 3,
+        geometry: 'Point',
+        attributeCount: 1,
+        attributes: [
+          {
+            attribute: 'test-attribute',
+            count: 3,
+            type: 'number',
+            values: [2, 5, 19],
+            min: 2,
+            max: 19,
+          },
+        ],
+      },
+    ],
+  };
+
+  const results = validator(stats);
+  t.equal(results.length, 1, 'only one error');
+  t.equal(results[0], 'instance.layers[0] requires property "layer"', 'expected error message');
+  t.end();
+});
+
+test('invalid layer object - no layer name', t => {
+  const stats = {
+    layerCount: 'wrong type',
+    layers: [
+      {
+        geometry: 'Point',
+        attributes: [
+          {
+            attribute: 'test-attribute',
+            type: 'number',
+            min: 2,
+            max: 19,
+          },
+        ],
+      },
+    ],
+  };
+
+  const expected = sloppySort([
+    'instance.layerCount is not of a type(s) number',
+    'instance.layers[0] requires property "count"',
+    'instance.layers[0].attributes[0] requires property "values"',
+    'instance.layers[0] requires property "layer"',
+    'instance.layers[0].attributes[0] requires property "count"',
+    'instance.layers[0] requires property "attributeCount"',
+  ]);
+
+  const results = validator(stats);
+  t.same(sloppySort(results), expected, 'expect lots of errors');
+  t.end();
+});
+
+test('invalid attributes contain mulitple types', t => {
+  const stats = {
+    layerCount: 1,
+    layers: [
+      {
+        layer: 'test-layer',
+        count: 3,
+        geometry: 'Point',
+        attributeCount: 1,
+        attributes: [
+          {
+            attribute: 'test-attribute',
+            count: 3,
+            type: 'number',
+            values: [2, 'five', null],
+            min: 2,
+            max: 19,
+          },
+        ],
+      },
+    ],
+  };
+
+  const results = validator(stats);
+  t.equal(results.length, 1, 'only one error');
+  t.equal(results[0], 'instance.layers[0].attributes[0].values is not any of [subschema 0],[subschema 1],[subschema 2],[subschema 3]', 'expected error message');
+  t.end();
+});


### PR DESCRIPTION
CD-2725

## Objective
Add the ability to generate json directly into mbtiles.

## Description
- Add an option`--into-md` to insert generated tilestats into mbtiles metadata
- `buildGeoStats` rejects promise instead of throwing an error (index.js rewritten into await/async)
- Split geostats and validator tests (structuring the tests)

## Acceptance
- added two tests:
  - option --into-md with non MBTiles file to test error handling
  - MBTiles with option --into-md; which tests writing, writing when stats already exist; reading the written stats

## Checklist

- [X] I have added relevant info to the CHANGELOG.md
