### PR TITLE
CL-272 Ignore translations option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Options
   --attributes, -a Specify attributes to analyze. The provided value
                    will be parsed as an array, split on commas.
   --force-all-attributes, -f Include values of these attributes: id,
-                             name, name1, name2, name_en, name_de,
-                             originalid, adm0_l, amd0_r, disputed_name,
-                             ref, fid, uuid.
+                              name, name1, name2, originalid, adm0_l, amd0_r,
+                              disputed_name, ref, fid, uuid.
+  --ignore-translations Exclude name translations attributes (name_int,
+                        name_de, name_en, name:*). Default: true.
   --tile-stats-values-limit Limit the number of unique attribute values to
                             report. Default: 50. If exceeded, show min and
                             max instead.

--- a/bin/mapbox-geostats
+++ b/bin/mapbox-geostats
@@ -16,9 +16,10 @@ const help = `
     --attributes, -a Specify attributes to analyze. The provided value
                      will be parsed as an array, split on commas.
     --force-all-attributes, -f Include values of these attributes: id,
-                               name, name1, name2, name_en, name_de,
-                               originalid, adm0_l, amd0_r, disputed_name,
-                               ref, fid, uuid.
+                               name, name1, name2, originalid, adm0_l, amd0_r,
+                               disputed_name, ref, fid, uuid.
+    --ignore-translations Exclude name translations attributes (name_int,
+                         name_de, name_en, name:*). Default: true.
     --tile-stats-values-limit Limit the number of unique attribute values to
                               report. Default: 50. If exceeded, show min and
                               max instead.
@@ -39,6 +40,10 @@ const cli = meow(help, {
       type: 'boolean',
       alias: 'f',
     },
+    ignoreTranslations: {
+      type: 'boolean',
+      default: true,
+    },
     tileStatsValuesLimit: {
       type: 'number',
       default: 50,
@@ -53,6 +58,7 @@ const input = cli.input[0];
 
 const options = {
   forceAllAttributes: cli.flags.forceAllAttributes,
+  ignoreTranslations: cli.flags.ignoreTranslations,
   maxValuesToReport: cli.flags.tileStatsValuesLimit,
   intoMd: cli.flags.intoMd,
 };

--- a/lib/register-attributes-map.js
+++ b/lib/register-attributes-map.js
@@ -2,6 +2,9 @@
 
 const registerAttribute = require('./register-attribute');
 
+const langTranslations = ['name_int', 'name_de', 'name_en'];
+const langRegex = /^name:.*$/;
+
 /**
  * Mutates a layer stats object to register stats
  * about an object of attributes (and returns the mutated object).
@@ -9,6 +12,7 @@ const registerAttribute = require('./register-attribute');
  * @param {Object} layerStats
  * @param {Object} options
  * @param {Set} [options.attributes] - Specific attributes that should be registered.
+ * @param {boolean} [options.ignoreTranslations] - Exclude name translations attributes.
  * @param {Object} attributes - The attributes to register, as an object
  *   of `name: value`
  * @return {Object} The mutated layerStats.
@@ -19,6 +23,10 @@ module.exports = function(layerStats, options, attributes) {
   Object.keys(attributes).forEach((name) => {
     const value = attributes[name];
     if (specifiedAttributes && !specifiedAttributes.has(name)) return;
+    else if (
+      !specifiedAttributes && options.ignoreTranslations &&
+      (langTranslations.includes(name) || langRegex.test(name))
+    ) return;
     registerAttribute(layerStats, options, name, value);
   });
 

--- a/lib/report-stats.js
+++ b/lib/report-stats.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const briefAttributes = ['id', 'name', 'name1', 'name2', 'name_en', 'name_de', 'originalid', 'adm0_l', 'amd0_r', 'disputed_name', 'ref', 'fid', 'uuid'];
+const briefAttributes = ['id', 'name', 'name1', 'name2', 'originalid', 'adm0_l', 'amd0_r', 'disputed_name', 'ref', 'fid', 'uuid'];
 
 /**
  * Returns an object bearing stats, formatted for output & reportage.

--- a/test/fixtures/expected/many-types-geojson-translations.json
+++ b/test/fixtures/expected/many-types-geojson-translations.json
@@ -1,0 +1,89 @@
+{
+  "layerCount": 1,
+  "layers": [
+    {
+      "layer": "many-types",
+      "attributeCount": 10,
+      "attributes": [
+        {
+          "values": [
+            true,
+            null
+          ],
+          "attribute": "astonishing",
+          "type": "boolean"
+        },
+        {
+          "values": ["enFuu", null],
+          "attribute": "name:en",
+          "type": "string"
+        },
+        {
+          "values": ["deFuu", null],
+          "attribute": "name_de",
+          "type": "string"
+        },
+        {
+          "values": [
+            7,
+            "7",
+            null
+          ],
+          "attribute": "mixed",
+          "type": "mixed"
+        },
+        {
+          "values": [
+            "foo",
+            "bar",
+            "baz",
+            "haha",
+            "hoho",
+            "hehe"
+          ],
+          "attribute": "name",
+          "type": "string"
+        },
+        {
+          "values": [
+            "[1,2,3]",
+            null
+          ],
+          "attribute": "numbers",
+          "type": "string"
+        },
+        {
+          "values": [
+            6,
+            99,
+            null,
+            86
+          ],
+          "attribute": "power",
+          "type": "number"
+        },
+        {
+          "values": [
+            6,
+            "{\"foo\":\"bar\"}"
+          ],
+          "attribute": "data",
+          "type": "mixed"
+        },
+        {
+          "values": [],
+          "attribute": "description",
+          "type": "string"
+        },
+        {
+          "values": [
+            null
+          ],
+          "attribute": "onlyNull",
+          "type": "null"
+        }
+      ],
+      "geometry": "Point"
+    }
+  ]
+}

--- a/test/fixtures/src/many-types.geojson
+++ b/test/fixtures/src/many-types.geojson
@@ -5,6 +5,8 @@
       "type": "Feature",
       "properties": {
         "name": "foo",
+        "name:en": "enFuu",
+        "name_de": "deFuu",
         "power": 6,
         "mixed": 7,
         "numbers": [1, 2, 3],

--- a/test/geostats.js
+++ b/test/geostats.js
@@ -59,8 +59,18 @@ t.test('Errors when Mapnik-interpreted file not found', t => {
 
 t.test('GeoJSON with many value types, input matching MBTiles, forceAllAttributes', t => {
   Promise.all([
-    geostats(fixturePath('src/many-types.geojson'), { forceAllAttributes: true }),
+    geostats(fixturePath('src/many-types.geojson'), { forceAllAttributes: true, ignoreTranslations: true }),
     getExpected('many-types-geojson'),
+  ]).then((output) => {
+    t.same(sloppySort(output[0]), sloppySort(output[1]), 'expected output');
+    t.end();
+  }).catch(t.threw);
+});
+
+t.test('GeoJSON with many value types, ignoreTranslations to false', t => {
+  Promise.all([
+    geostats(fixturePath('src/many-types.geojson'), { forceAllAttributes: true }),
+    getExpected('many-types-geojson-translations'),
   ]).then((output) => {
     t.same(sloppySort(output[0]), sloppySort(output[1]), 'expected output');
     t.end();


### PR DESCRIPTION
CL-272

## Objective
Add option `--ignore-translations`, with default set to `true`.
If True, do not add these attributes into tilestats at all: `name_int`, `name_de`, `name_en`, `name:*`.

## Description
Has higher priority than `--force-all-attributes`. Lower priority than `--attributes`.

## Acceptance
- [X] added test case (updated many-types.geojson)
