### PR TITLE
CL-273 Add option for briefAttributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Options
   --brief-attributes Override default values for brief attributes. Provided
                      value will be parsed as an array, split on commas.
                      Cannot be used with --force-all-attributes.
-  --force-all-attributes, -f Include values of brief-attributes. Cannot be
+  --force-all-attributes, -f Include values of brief attributes. Cannot be
                              used with --brief-attributes.
   --ignore-translations Exclude name translations attributes (name_int,
                         name_de, name_en, name:*). Default: true.

--- a/README.md
+++ b/README.md
@@ -58,13 +58,17 @@ Usage
 
   Output is logged to the console as a JSON string or written into mbtiles
   when using --into-md option.
+  By default ignoring values of these brief attributes: id, name, name1,
+  name2, originalid, adm0_l, amd0_r, disputed_name, ref, fid, uuid.
 
 Options
   --attributes, -a Specify attributes to analyze. The provided value
-                   will be parsed as an array, split on commas.
-  --force-all-attributes, -f Include values of these attributes: id,
-                              name, name1, name2, originalid, adm0_l, amd0_r,
-                              disputed_name, ref, fid, uuid.
+                    will be parsed as an array, split on commas.
+  --brief-attributes Override default values for brief attributes. Provided
+                      value will be parsed as an array, split on commas.
+                      Cannot be used with --force-all-attributes.
+  --force-all-attributes, -f Include values of brief-attributes. Cannot be
+                              used with --brief-attributes.
   --ignore-translations Exclude name translations attributes (name_int,
                         name_de, name_en, name:*). Default: true.
   --tile-stats-values-limit Limit the number of unique attribute values to

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ Usage
 
 Options
   --attributes, -a Specify attributes to analyze. The provided value
-                    will be parsed as an array, split on commas.
+                   will be parsed as an array, split on commas.
   --brief-attributes Override default values for brief attributes. Provided
-                      value will be parsed as an array, split on commas.
-                      Cannot be used with --force-all-attributes.
+                     value will be parsed as an array, split on commas.
+                     Cannot be used with --force-all-attributes.
   --force-all-attributes, -f Include values of brief-attributes. Cannot be
-                              used with --brief-attributes.
+                             used with --brief-attributes.
   --ignore-translations Exclude name translations attributes (name_int,
                         name_de, name_en, name:*). Default: true.
   --tile-stats-values-limit Limit the number of unique attribute values to

--- a/bin/mapbox-geostats
+++ b/bin/mapbox-geostats
@@ -20,7 +20,7 @@ const help = `
     --brief-attributes Override default values for brief attributes. Provided
                        value will be parsed as an array, split on commas.
                        Cannot be used with --force-all-attributes.
-    --force-all-attributes, -f Include values of brief-attributes. Cannot be
+    --force-all-attributes, -f Include values of brief attributes. Cannot be
                                used with --brief-attributes.
     --ignore-translations Exclude name translations attributes (name_int,
                          name_de, name_en, name:*). Default: true.

--- a/bin/mapbox-geostats
+++ b/bin/mapbox-geostats
@@ -11,13 +11,17 @@ const help = `
 
     Output is logged to the console as a JSON string or written into mbtiles
     when using --into-md option.
+    By default ignoring values of these brief attributes: id, name, name1,
+    name2, originalid, adm0_l, amd0_r, disputed_name, ref, fid, uuid.
 
   Options
     --attributes, -a Specify attributes to analyze. The provided value
                      will be parsed as an array, split on commas.
-    --force-all-attributes, -f Include values of these attributes: id,
-                               name, name1, name2, originalid, adm0_l, amd0_r,
-                               disputed_name, ref, fid, uuid.
+    --brief-attributes Override default values for brief attributes. Provided
+                       value will be parsed as an array, split on commas.
+                       Cannot be used with --force-all-attributes.
+    --force-all-attributes, -f Include values of brief-attributes. Cannot be
+                               used with --brief-attributes.
     --ignore-translations Exclude name translations attributes (name_int,
                          name_de, name_en, name:*). Default: true.
     --tile-stats-values-limit Limit the number of unique attribute values to

--- a/bin/mapbox-geostats
+++ b/bin/mapbox-geostats
@@ -36,6 +36,9 @@ const cli = meow(help, {
       type: 'string',
       alias: 'a',
     },
+    briefAttributes: {
+      type: 'string',
+    },
     forceAllAttributes: {
       type: 'boolean',
       alias: 'f',
@@ -62,6 +65,11 @@ const options = {
   maxValuesToReport: cli.flags.tileStatsValuesLimit,
   intoMd: cli.flags.intoMd,
 };
+
+if (cli.flags.briefAttributes) {
+  if (options.forceAllAttributes) return console.error('Cannot use --force-all-attributes with --brief-attributes');
+  options.briefAttributes = cli.flags.briefAttributes.split(',');
+}
 
 if (cli.flags.attributes) {
   options.attributes = cli.flags.attributes.split(',');

--- a/lib/report-stats.js
+++ b/lib/report-stats.js
@@ -1,21 +1,24 @@
 'use strict';
 
-const briefAttributes = ['id', 'name', 'name1', 'name2', 'originalid', 'adm0_l', 'amd0_r', 'disputed_name', 'ref', 'fid', 'uuid'];
+const briefAttributesDefault = ['id', 'name', 'name1', 'name2', 'originalid', 'adm0_l', 'amd0_r', 'disputed_name', 'ref', 'fid', 'uuid'];
 
 /**
  * Returns an object bearing stats, formatted for output & reportage.
  *
  * @param {Object} stats - See create-layer-stats.js
  * @param {Object} options
- *   options.attributes: string[] - Attributes to analyze.
- *   options.forceAllAttributes: boolean - Include values of briefAttributes.
- *   options.maxValuesToReport: number - The maximum number of unique attribute values to record.
+ *   @param {string[]} [options.attributes]
+ *   @param {string[]} [options.briefAttributes]
+ *   @param {boolean} [options.forceAllAttributes]
+ *   @param {number} [options.maxValuesToReport]
  * @return {Object} The report, which adheres to the relevant JSON schema.
  */
 module.exports = function(stats, options) {
 
   // if we have a stats object already built from an mbtiles file
   if (!stats.layerCountSet && Number.isInteger(stats.layerCount)) return stats;
+
+  const briefAttributes = options.briefAttributes || briefAttributesDefault;
 
   return {
     layerCount: stats.layerCountSet.size,

--- a/test/fixtures/expected/many-types-geojson-translations.json
+++ b/test/fixtures/expected/many-types-geojson-translations.json
@@ -53,14 +53,10 @@
           "type": "string"
         },
         {
-          "values": [
-            6,
-            99,
-            null,
-            86
-          ],
           "attribute": "power",
-          "type": "number"
+          "type": "number",
+          "min": 6,
+          "max": 99
         },
         {
           "values": [

--- a/test/geostats.js
+++ b/test/geostats.js
@@ -67,9 +67,9 @@ t.test('GeoJSON with many value types, input matching MBTiles, forceAllAttribute
   }).catch(t.threw);
 });
 
-t.test('GeoJSON with many value types, ignoreTranslations to false', t => {
+t.test('GeoJSON with many value types, ignoreTranslations to false, briefAttributes to power', t => {
   Promise.all([
-    geostats(fixturePath('src/many-types.geojson'), { forceAllAttributes: true }),
+    geostats(fixturePath('src/many-types.geojson'), { briefAttributes: 'power' }),
     getExpected('many-types-geojson-translations'),
   ]).then((output) => {
     t.same(sloppySort(output[0]), sloppySort(output[1]), 'expected output');


### PR DESCRIPTION
CL-273

## Objective
Setting this option overrides the default values (`id`, `name`, `name1`, `name2`, `originalid`, `adm0_l`, `amd0_r`, `disputed_name`, `ref`, `fid`, `uuid`).

## Description
Options `--force-all-attributes` and `--brief-attributes` cannot be used at the same time, an error is displayed instead. Option has lower priority than `--ignore-translations`.

Updated confluence page: https://maptiler.atlassian.net/wiki/spaces/~287587938/pages/1645740040/Tilestats+Geostats+-+mapbox+geostats+tools+modification#Option---briefAttributes

## Acceptance
- [X] updated tests to cover this option