### PR TITLE
CL-274 Fix geometry type

### DIFF
--- a/lib/create-layer-stats.js
+++ b/lib/create-layer-stats.js
@@ -12,6 +12,6 @@ module.exports = function(name) {
     attributes: Object.create(null),
     attributeCountSet: new Set(),
     attributeCount: 0,
-    geometryCounts: Object.create(null),
+    geometry: new Set(),
   };
 };

--- a/lib/register-feature.js
+++ b/lib/register-feature.js
@@ -10,7 +10,6 @@
  * @return {Object} The mutated layerStats.
  */
 module.exports = function(layerStats, featureData) {
-  layerStats.geometryCounts[featureData.type] = 1 +
-    (layerStats.geometryCounts[featureData.type] || 0);
+  layerStats.geometry.add(featureData.type);
   return layerStats;
 };

--- a/lib/report-stats.js
+++ b/lib/report-stats.js
@@ -30,16 +30,9 @@ module.exports = function(stats, options) {
       attributes: Object.values(layerStats.attributes).map(reportAttribute),
     };
 
-    let dominantGeometry;
-    let dominantGeometryCount = 0;
-    Object.keys(layerStats.geometryCounts).forEach((geometry) => {
-      const count = layerStats.geometryCounts[geometry];
-      if (count > dominantGeometryCount) {
-        dominantGeometryCount = count;
-        dominantGeometry = geometry;
-      }
-    });
-    if (dominantGeometry) result.geometry = dominantGeometry;
+    const geometry = Array.from(layerStats.geometry);
+    if (geometry.length > 1) result.geometry = geometry;
+    else if (geometry.length === 1) result.geometry = geometry[0];
 
     return result;
   }

--- a/lib/validate-stats.js
+++ b/lib/validate-stats.js
@@ -4,6 +4,7 @@ const Validator = require('jsonschema').Validator;
 const schema = require('../schema/tilestats.json');
 const layerSchema = require('../schema/layer.json');
 const attributeSchema = require('../schema/attribute.json');
+const geometrySchema = require('../schema/geometry.json');
 
 /**
  * Check if a stats JSON object is valid
@@ -15,6 +16,7 @@ module.exports = function(stats) {
   const v = new Validator();
   v.addSchema(layerSchema, '/layer');
   v.addSchema(attributeSchema, '/attribute');
+  v.addSchema(geometrySchema, '/geometry');
 
   const results = v.validate(stats, schema);
   if (!results.errors.length) return true;

--- a/schema/geometry.json
+++ b/schema/geometry.json
@@ -1,0 +1,13 @@
+{
+  "id": "/geometry",
+  "type": "string",
+  "enum": [
+    "GeometryCollection",
+    "LineString",
+    "MultiLineString",
+    "MultiPoint",
+    "MultiPolygon",
+    "Point",
+    "Polygon"
+  ]
+}

--- a/schema/layer.json
+++ b/schema/layer.json
@@ -5,8 +5,10 @@
     "layer": { "type": "string" },
     "count": { "type": "number" },
     "geometry": {
-      "type": "string",
-      "enum": [ "Point", "LineString", "Polygon" ]
+      "anyOf": [
+        { "$ref": "/geometry" },
+        { "type": "array", "items": { "$ref": "/geometry" } }
+      ]
     },
     "attributeCount": { "type": "number" },
     "attributes": {

--- a/test/fixtures/expected/geometry-extravaganza.json
+++ b/test/fixtures/expected/geometry-extravaganza.json
@@ -37,7 +37,7 @@
           "type": "boolean"
         }
       ],
-      "geometry": "Point"
+      "geometry": ["GeometryCollection", "MultiLineString", "MultiPoint", "MultiPolygon", "Point"]
     }
   ]
 }

--- a/test/fixtures/expected/many-types-geojson-name-only.json
+++ b/test/fixtures/expected/many-types-geojson-name-only.json
@@ -11,7 +11,7 @@
           "values": ["foo", "bar", "baz", "haha", "hoho", "hehe"]
         }
       ],
-      "geometry": "Point"
+      "geometry": ["LineString", "Point", "Polygon"]
     }
   ]
 }

--- a/test/fixtures/expected/many-types-geojson-translations.json
+++ b/test/fixtures/expected/many-types-geojson-translations.json
@@ -83,7 +83,7 @@
           "type": "null"
         }
       ],
-      "geometry": "Point"
+      "geometry": ["LineString", "Point", "Polygon"]
     }
   ]
 }

--- a/test/fixtures/expected/many-types-geojson.json
+++ b/test/fixtures/expected/many-types-geojson.json
@@ -73,7 +73,7 @@
           "type": "null"
         }
       ],
-      "geometry": "Point"
+      "geometry": ["LineString", "Point", "Polygon"]
     }
   ]
 }

--- a/test/fixtures/expected/many-types-mbtiles.json
+++ b/test/fixtures/expected/many-types-mbtiles.json
@@ -54,7 +54,7 @@
           "type": "string"
         }
       ],
-      "geometry": "Point"
+      "geometry": ["LineString", "Point", "Polygon"]
     }
   ]
 }

--- a/test/fixtures/expected/prototype.json
+++ b/test/fixtures/expected/prototype.json
@@ -21,7 +21,7 @@
           ]
         }
       ],
-      "geometry": "Point",
+      "geometry": ["LineString", "Point"],
       "layer": "prototype"
     }
   ]


### PR DESCRIPTION
CL-274

## Objective
Report layer geometry as a string or an array if there are multiple types.

## Description
Layer geometry can be:
 - string (one type)
- array (multiple types)
- missing (no features)

## Acceptance
- [X] updated tests in 7d0e45358149836103d637dcb0ae282850ee8b89