### PR TITLE
CL-284 Optional count and values in validation

### DIFF
--- a/bin/mapbox-geostats-validate
+++ b/bin/mapbox-geostats-validate
@@ -26,11 +26,11 @@ try {
   const raw = fs.readFileSync(file);
   console.log(raw);
   stats = JSON.parse(raw);
-  // stats = JSON.parse(fs.readFileSync(file));
 } catch (err) {
-  console.log('Unable to read file');
+  console.log('Unable to read JSON file');
   console.error(err);
   console.log(help);
+  return;
 }
 
 const results = validate(stats);

--- a/schema/attribute.json
+++ b/schema/attribute.json
@@ -19,5 +19,5 @@
     "min": { "type": "number" },
     "max": { "type": "number" }
   },
-  "required": [ "attribute", "count", "type", "values" ]
+  "required": [ "attribute", "type" ]
 }

--- a/schema/layer.json
+++ b/schema/layer.json
@@ -14,5 +14,5 @@
       "items": { "$ref": "/attribute" }
     }
   },
-  "required": [ "layer", "count", "geometry", "attributeCount" ]
+  "required": [ "layer", "geometry", "attributeCount" ]
 }

--- a/test/validator.js
+++ b/test/validator.js
@@ -90,10 +90,7 @@ test('invalid layer object - no layer name', t => {
 
   const expected = sloppySort([
     'instance.layerCount is not of a type(s) number',
-    'instance.layers[0] requires property "count"',
-    'instance.layers[0].attributes[0] requires property "values"',
     'instance.layers[0] requires property "layer"',
-    'instance.layers[0].attributes[0] requires property "count"',
     'instance.layers[0] requires property "attributeCount"',
   ]);
 


### PR DESCRIPTION
CL-284

## Objective
Fix tilestats validator, so it takes into account the modifications done previously.

## Description
Make count and values optional in validating schema.

## Acceptance
All the reported issues from the example should be gone. Updated tests of the validator.