### PR TITLE
CL-557 Add option to generate languages stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Options
                             report. Default: 50. If exceeded, show min and
                             max instead.
   --add-languages Save all the languages from the vector data into the
-                  metadata languages array. Default: true.
+                  tilestats as languages array. Default: true.
   --into-md Insert generated tilestats into mbtiles metadata table. Fail
             when tilestats already exist. Output is empty on success.
 
@@ -125,7 +125,9 @@ The tilestats jsonschema is specified in the /schema directory under schema/tile
 The stats output has this structure:
 
 ```js
-{  
+{
+  // The list of all languages in the vector data
+  "languages": Array<string>
   // The number of layers in the source data (max. 1000)
   "layerCount": Number,
   // An array of details about the first 100 layers
@@ -133,10 +135,8 @@ The stats output has this structure:
     {
       // The name of this layer
       "layer": String,
-      // The number of features in this layer
-      "count": Number,
-      // The dominant geometry type in this layer
-      "geometry": String,
+      // The geometry type(s) in this layer
+      "geometry": String | Array<String>,
       // The number of unique attributes in this layer (max. 1000)
       "attributeCount": Number
       // An array of details about the first 100 attributes in this layer
@@ -144,16 +144,14 @@ The stats output has this structure:
         {
           // The name of this attribute
           "attribute": String,
-          // The number of unique values for this attribute (max. 1000)
-          "count": Number,
           // The type of this attribute's values
           "type": String, // More info below ...
-          // An array of this attribute's first 100 unique values
+          // An array of this attribute's if less than VALUES LIMIT unique values
           "values": [
             // ...
           ],
-          // If there are *any* numbers in the values, the following
-          // numeric stats will be reported
+          // If there are more number values than VALUES LIMIT, the following
+          // numeric stats will be reported instead
           "min": Number,
           "max": Number
         }

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Options
   --tile-stats-values-limit Limit the number of unique attribute values to
                             report. Default: 50. If exceeded, show min and
                             max instead.
+  --add-languages Save all the languages from the vector data into the
+                  metadata languages array. Default: true.
   --into-md Insert generated tilestats into mbtiles metadata table. Fail
             when tilestats already exist. Output is empty on success.
 

--- a/bin/mapbox-geostats
+++ b/bin/mapbox-geostats
@@ -28,7 +28,7 @@ const help = `
                               report. Default: 50. If exceeded, show min and
                               max instead.
     --add-languages Save all the languages from the vector data into the
-                    metadata languages array. Default: true.
+                    tilestats as languages array. Default: true.
     --into-md Insert generated tilestats into mbtiles metadata table. Fail
               when tilestats already exist. Output is empty on success.
 

--- a/bin/mapbox-geostats
+++ b/bin/mapbox-geostats
@@ -27,6 +27,8 @@ const help = `
     --tile-stats-values-limit Limit the number of unique attribute values to
                               report. Default: 50. If exceeded, show min and
                               max instead.
+    --add-languages Save all the languages from the vector data into the
+                    metadata languages array. Default: true.
     --into-md Insert generated tilestats into mbtiles metadata table. Fail
               when tilestats already exist. Output is empty on success.
 
@@ -58,6 +60,10 @@ const cli = meow(help, {
     intoMd: {
       type: 'boolean',
     },
+    addLanguages: {
+      type: 'boolean',
+      default: true,
+    },
   },
 });
 
@@ -67,6 +73,7 @@ const options = {
   forceAllAttributes: cli.flags.forceAllAttributes,
   ignoreTranslations: cli.flags.ignoreTranslations,
   maxValuesToReport: cli.flags.tileStatsValuesLimit,
+  addLanguages: cli.flags.addLanguages,
   intoMd: cli.flags.intoMd,
 };
 

--- a/lib/create-stats.js
+++ b/lib/create-stats.js
@@ -7,6 +7,7 @@
  */
 module.exports = function() {
   return {
+    languages: new Set(),
     layerCountSet: new Set(),
     layers: [],
   };

--- a/lib/mapnik-analyze.js
+++ b/lib/mapnik-analyze.js
@@ -66,7 +66,7 @@ module.exports = function(filePath, fileType, options) {
         type: typeIntegerToString(feature.geometry().type()),
       });
 
-      registerAttributesMap(layerStats, options, feature.attributes());
+      registerAttributesMap(stats, layerStats, options, feature.attributes());
 
       feature = features.next();
     }

--- a/lib/register-attributes-map.js
+++ b/lib/register-attributes-map.js
@@ -3,30 +3,39 @@
 const registerAttribute = require('./register-attribute');
 
 const langTranslations = ['name_int', 'name_de', 'name_en'];
-const langRegex = /^name:.*$/;
+const langRegex = /^name:(.*)$/;
 
 /**
  * Mutates a layer stats object to register stats
  * about an object of attributes (and returns the mutated object).
  *
+ * @return {Object} stats
  * @param {Object} layerStats
  * @param {Object} options
- * @param {Set} [options.attributes] - Specific attributes that should be registered.
- * @param {boolean} [options.ignoreTranslations] - Exclude name translations attributes.
+ *   @param {Set} [options.attributes]
+ *   @param {boolean} [options.ignoreTranslations]
+ *   @param {boolean} [options.addLanguages]
  * @param {Object} attributes - The attributes to register, as an object
  *   of `name: value`
  * @return {Object} The mutated layerStats.
  */
-module.exports = function(layerStats, options, attributes) {
+module.exports = function(stats, layerStats, options, attributes) {
   const specifiedAttributes = options.attributes;
 
   Object.keys(attributes).forEach((name) => {
     const value = attributes[name];
+
+    if (options.addLanguages) {
+      const lang = langRegex.exec(name);
+      if (lang) stats.languages.add(lang[1]);
+    }
+
     if (specifiedAttributes && !specifiedAttributes.has(name)) return;
     else if (
       !specifiedAttributes && options.ignoreTranslations &&
       (langTranslations.includes(name) || langRegex.test(name))
     ) return;
+
     registerAttribute(layerStats, options, name, value);
   });
 

--- a/lib/report-stats.js
+++ b/lib/report-stats.js
@@ -11,6 +11,7 @@ const briefAttributesDefault = ['id', 'name', 'name1', 'name2', 'originalid', 'a
  *   @param {string[]} [options.briefAttributes]
  *   @param {boolean} [options.forceAllAttributes]
  *   @param {number} [options.maxValuesToReport]
+ *   @param {boolean} [options.addLanguages]
  * @return {Object} The report, which adheres to the relevant JSON schema.
  */
 module.exports = function(stats, options) {
@@ -20,11 +21,16 @@ module.exports = function(stats, options) {
 
   const briefAttributes = options.briefAttributes || briefAttributesDefault;
 
-  return {
+  const result = {
     layerCount: stats.layerCountSet.size,
     layers: stats.layers.map(reportLayer),
   };
 
+  if (options.addLanguages) {
+    result.languages = Array.from(stats.languages);
+  }
+
+  return result;
 
   function reportLayer(layerStats) {
     const result = {

--- a/lib/tile-analyze.js
+++ b/lib/tile-analyze.js
@@ -182,7 +182,7 @@ function analyzeTile(tile, stats, layerMap, options) {
       for (const layerName in vectorTile.layers) {
         if (Object.hasOwnProperty.call(vectorTile.layers, layerName)) {
           const layerData = vectorTile.layers[layerName];
-          analyzeLayer(layerData, layerName, stats.layerCountSet, layerMap, options);
+          analyzeLayer(stats, layerData, layerName, layerMap, options);
         }
       }
       resolve();
@@ -190,24 +190,24 @@ function analyzeTile(tile, stats, layerMap, options) {
   });
 }
 
-function analyzeLayer(layerData, rawLayerName, layerCountSet, layerMap, options) {
+function analyzeLayer(stats, layerData, rawLayerName, layerMap, options) {
   const layerName = rawLayerName.slice(0, Constants.NAME_TRUNCATE_LENGTH);
   if (layerMap[layerName] === undefined) {
-    if (layerCountSet.size > Constants.LAYERS_MAX_COUNT) return;
-    layerCountSet.add(layerName);
+    if (stats.layerCountSet.size > Constants.LAYERS_MAX_COUNT) return;
+    stats.layerCountSet.add(layerName);
 
-    if (layerCountSet.size > Constants.LAYERS_MAX_REPORT) return;
+    if (stats.layerCountSet.size > Constants.LAYERS_MAX_REPORT) return;
     layerMap[layerName] = createLayerStats(layerName);
   }
   const layerStats = layerMap[layerName];
   for (let i = 0, l = layerData.length; i < l; i++) {
-    analyzeFeature(layerStats, layerData.feature(i), options);
+    analyzeFeature(stats, layerStats, layerData.feature(i), options);
   }
 }
 
-function analyzeFeature(layerStats, feature, options) {
+function analyzeFeature(stats, layerStats, feature, options) {
   registerFeature(layerStats, {
     type: typeIntegerToString(feature.type),
   });
-  registerAttributesMap(layerStats, options, feature.properties);
+  registerAttributesMap(stats, layerStats, options, feature.properties);
 }

--- a/schema/tilestats.json
+++ b/schema/tilestats.json
@@ -6,6 +6,10 @@
     "layers": {
       "type": "array",
       "items": { "$ref": "/layer" }
+    },
+    "languages": {
+      "type": "array",
+      "items": { "type": "string" }
     }
   },
   "required": [ "layerCount", "layers" ]

--- a/test/fixtures/expected/many-types-geojson-translations.json
+++ b/test/fixtures/expected/many-types-geojson-translations.json
@@ -1,9 +1,10 @@
 {
+  "languages": ["en", "it"],
   "layerCount": 1,
   "layers": [
     {
       "layer": "many-types",
-      "attributeCount": 10,
+      "attributeCount": 11,
       "attributes": [
         {
           "values": [
@@ -16,6 +17,11 @@
         {
           "values": ["enFuu", null],
           "attribute": "name:en",
+          "type": "string"
+        },
+        {
+          "values": ["itBar", null],
+          "attribute": "name:it",
           "type": "string"
         },
         {

--- a/test/fixtures/src/many-types.geojson
+++ b/test/fixtures/src/many-types.geojson
@@ -24,6 +24,7 @@
       "type": "Feature",
       "properties": {
         "name": "bar",
+        "name:it": "itBar",
         "mixed": "7",
         "power": 99
       },

--- a/test/geostats.js
+++ b/test/geostats.js
@@ -67,9 +67,9 @@ t.test('GeoJSON with many value types, input matching MBTiles, forceAllAttribute
   }).catch(t.threw);
 });
 
-t.test('GeoJSON with many value types, ignoreTranslations to false, briefAttributes to power', t => {
+t.test('GeoJSON, ignoreTranslations to false, briefAttributes to power, addLanguages to true', t => {
   Promise.all([
-    geostats(fixturePath('src/many-types.geojson'), { briefAttributes: 'power' }),
+    geostats(fixturePath('src/many-types.geojson'), { briefAttributes: 'power', addLanguages: true }),
     getExpected('many-types-geojson-translations'),
   ]).then((output) => {
     t.same(sloppySort(output[0]), sloppySort(output[1]), 'expected output');


### PR DESCRIPTION
CL-557

## Objective
Add option `--add-languages=true`, with the default set to true. It saves all languages from vector data into the metadata languages section.

## Description
New `languages` array added into tilestats json. It's an array of language codes derivated from `name:xx` attributes. Attributes `lang_en` and are not included.

## Acceptance
Updated test with `many-types.geojson` and `many-types-geojson-translations.json` fixture to test this feature.