### PR TITLE
CL-356 Fix error writing metadata

### DIFF
--- a/lib/tile-analyze.js
+++ b/lib/tile-analyze.js
@@ -89,17 +89,13 @@ module.exports = async function tileAnalyze(filePath, options) {
  */
 function writeMetadata(mbtiles, metadata) {
   return new Promise((resolve, reject) => {
-    mbtiles.startWriting(function(err) {
+    const jsonRow = { json: JSON.stringify(metadata) };
+    mbtiles._isWritable = true;
+    mbtiles.putInfo(jsonRow, function(err) {
       if (err) return reject(err);
-
-      const jsonRow = { json: JSON.stringify(metadata) };
-      mbtiles.putInfo(jsonRow, function(err) {
+      mbtiles.stopWriting(function(err) {
         if (err) return reject(err);
-
-        mbtiles.stopWriting(function(err) {
-          if (err) return reject(err);
-          resolve();
-        });
+        resolve();
       });
     });
   });


### PR DESCRIPTION
CL-356

## Objective
There was an error when writing tilestats direcltly into metadata with `--into-md` option when the mbtiles had a faulty schema.

## Description
Skip schema check when writing metadata. We only care if the metadata table is writable, nothing else. This can also improve the writing speed of the metadata into mbtiles. This is quite hacky, but I went through mbtiles library code and it should be fine.

Writing into `maptiler-ocean-2022-10-21-v1.3-z0-z12.mbtiles` (3.21GB):
- before: fail after 87 s
- after: done after 0.4 s

## Acceptance
- tests were not changed
- **Adam, please test it**
